### PR TITLE
Remove unused imports

### DIFF
--- a/tessilator/acf_functions.py
+++ b/tessilator/acf_functions.py
@@ -6,12 +6,9 @@
 # imports
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
-import lightkurve as lk
 from statsmodels.tsa.stattools import acf
-from scipy.signal import find_peaks, peak_prominences
+from scipy.signal import find_peaks
 from scipy.optimize import curve_fit
-from scipy import stats
 
 # UNIVERSAL VARIABLES
 

--- a/tessilator/aperture.py
+++ b/tessilator/aperture.py
@@ -20,15 +20,12 @@ coordinates to image (x-y) pixels.
 ####################################IMPORTS####################################
 ###############################################################################
 # Internal
-import warnings
 import inspect
 import sys
 
 # Third party
 import numpy as np
-import json
 
-from scipy import stats
 
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
@@ -42,7 +39,7 @@ from photutils.aperture import aperture_photometry, ApertureStats
 
 
 # Local application
-from .fixedconstants import pixel_size, exprf, Zpt, eZpt, sec_max
+from .fixedconstants import Zpt
 from .file_io import logger_tessilator
 ###############################################################################
 ###############################################################################

--- a/tessilator/contaminants.py
+++ b/tessilator/contaminants.py
@@ -25,17 +25,15 @@ that of the target, or from neighbouring sources.
 ###############################################################################
 ####################################IMPORTS####################################
 ###############################################################################
-#Internal
-import warnings
+# Internal
 import inspect
 import sys
-import traceback
 import math
 
 # Third party imports
 import numpy as np
 from astroquery.gaia import Gaia
-from astropy.table import Table, Row
+from astropy.table import Table
 
 
 # Local application

--- a/tessilator/detrend_cbv.py
+++ b/tessilator/detrend_cbv.py
@@ -24,9 +24,7 @@ import numpy as np
 import os
 import subprocess
 
-from astropy.table import Table
 from astropy.io import fits
-import astropy.units as u
 
 import pylab as pl
 

--- a/tessilator/file_io.py
+++ b/tessilator/file_io.py
@@ -1,5 +1,11 @@
+"""
+
+Alexander Binks & Moritz Guenther, December 2024
+
+Licence: MIT 2024
+"""
+
 import os
-from astropy.table import Table
 import logging
 import sys
 

--- a/tessilator/lc_analysis.py
+++ b/tessilator/lc_analysis.py
@@ -24,8 +24,7 @@ which are called by the parent function 'run_make_lc_steps'. The steps are:
 ###############################################################################
 ####################################IMPORTS####################################
 ###############################################################################
-#Internal
-import warnings
+# Internal
 import inspect
 import sys
 
@@ -36,12 +35,10 @@ import os
 import json
 
 from astropy.table import Table
-import astropy.units as u
 from astropy.stats import akaike_info_criterion_lsq
 
 from scipy.stats import median_abs_deviation as MAD
 from scipy.optimize import curve_fit
-from scipy.stats import iqr
 
 import itertools as it
 from operator import itemgetter

--- a/tessilator/makeplots.py
+++ b/tessilator/makeplots.py
@@ -11,13 +11,11 @@ Generate pixel images, light-curves and periodogram plots
 ###############################################################################
 ####################################IMPORTS####################################
 ###############################################################################
-#Internal
-import os
+# Internal
 import sys
 import inspect
 
 # Third party
-from astropy.table import Table
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt

--- a/tessilator/maketable.py
+++ b/tessilator/maketable.py
@@ -21,7 +21,6 @@ import inspect
 
 #Third party
 from astropy.table import Table
-from astropy.io import ascii
 from astroquery.simbad import Simbad
 from astroquery.gaia import Gaia
 from astropy.coordinates import SkyCoord, ICRS

--- a/tessilator/periodogram.py
+++ b/tessilator/periodogram.py
@@ -16,22 +16,14 @@ import warnings
 
 # Third party imports
 import numpy as np
-import os
 import matplotlib.pyplot as plt
 import sys
 import inspect
 
 from astropy.table import Table
-from astropy.coordinates import SkyCoord
 from astropy.timeseries import LombScargle
-from astropy.wcs import WCS
-from astropy.io import fits
-import astropy.units as u
-from astropy.stats import akaike_info_criterion_lsq
 
 from scipy.stats import median_abs_deviation as MAD
-from scipy.stats import mode
-from scipy.stats import chi2
 
 from scipy.optimize import curve_fit
 import itertools as it

--- a/tessilator/tess_stars2px.py
+++ b/tessilator/tess_stars2px.py
@@ -131,18 +131,10 @@ from astropy.time import Time
 import sys
 import datetime
 import json
-try: # Python 3.x
-    from urllib.parse import quote as urlencode
-    from urllib.request import urlretrieve
-    from urllib.parse import urlparse
-except ImportError:  # Python 2.x
-    from urllib import pathname2url as urlencode
-    from urllib import urlretrieve
-    from urlparse import urlparse
-try: # Python 3.x
-    import http.client as httplib 
-except ImportError:  # Python 2.x
-    import httplib
+
+from urllib.parse import quote as urlencode
+from urllib.parse import urlparse
+import http.client as httplib
 import scipy.optimize as opt
 import base64
 

--- a/tessilator/tessilator.py
+++ b/tessilator/tessilator.py
@@ -26,36 +26,20 @@ from collections.abc import Iterable
 from astropy.table import Table
 from astropy.io import ascii, fits
 from astropy.coordinates import SkyCoord
-import astropy.units as u
 from astroquery.mast import Tesscut
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import math
 
 # Local application imports
-from .aperture import get_xy_pos, calc_rad, aper_run
-from .lc_analysis import get_time_segments, remove_sparse_data, aic_selector,\
-                         relative_root_mean_squared_error, smooth_test,\
-                         norm_choice, detrend_lc, clean_flux_algorithm,\
-                         clean_edges_outlier, clean_edges_scatter,\
-                         run_make_lc_steps, sin_fit, sin_fit_per,\
-                         cbv_fit_test, make_lc
-from .periodogram import check_for_jumps, gauss_fit, gauss_fit_peak,\
-                         get_next_peak, mean_of_arrays, get_Gauss_params_pg,\
-                         initialise_LS_dict, write_periodogram,\
-                         get_periodogram_peaks, shuffle_periodogram,\
-                         plotticks_shuffle, shuffle_check, make_phase_curve,\
-                         run_ls
-from .detrend_cbv import logdet, bayes_linear_fit_ard, savgol_filter,\
-                         block_mean, cdpp, medransig, fit_basis, apply_basis,\
-                         fixed_nb, sel_nb, interpolate_cbv, get_cbv_scc
-from .contaminants import run_sql_query_contaminants,\
-                          flux_fraction_contaminant, contamination,\
-                          is_period_cont
-from .maketable import table_from_simbad, get_twomass_like_name,\
-                       table_from_coords, table_from_table, get_gaia_data
+from .aperture import aper_run
+from .lc_analysis import make_lc
+from .periodogram import run_ls
+from .detrend_cbv import get_cbv_scc
+from .contaminants import contamination, is_period_cont
+from .maketable import get_gaia_data
 from .makeplots import make_plot
-from .fixedconstants import pixel_size, exprf, Zpt, eZpt, sec_max
+from .fixedconstants import sec_max
 from .file_io import logger_tessilator, make_dir, fix_table_format
 from .tess_stars2px import tess_stars2px_function_entry
 


### PR DESCRIPTION
Because if they ae not used, why import them?
Don't worry, I did not do that by hand, it's a feature my editor does for me.

For the `tessilator.py` itself, it's a question of we want to do that because that means that also would not get added to `__all__`. Personally, I'd prefer if users import them for where they comes from and not from tessilator itself, because then you end up in a similar situation as you do with "*" imports - you get a bunch of functions, but don't really know where they come from.
 but there might valid reasons to do it this was. It's just a question of design, so we might want to discuss that.