### PR TITLE
Fix process_LightCurve for invalid choice of `prot_prior`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     scipy
     matplotlib
     pyinputplus
+    statsmodels
 
 [options.entry_points]
 console_scripts =

--- a/tessilator/tests/test_ac_fuctions.py
+++ b/tessilator/tests/test_ac_fuctions.py
@@ -1,0 +1,10 @@
+# Licence: MIT
+
+import pytest
+from tessilator.acf_functions import process_LightCurve
+
+
+def test_process_LightCurve_prot_prior_value_error():
+    """Test we error out with invalid prot_prior value. The other parameters don't matter in this case."""
+    with pytest.raises(ValueError):
+        process_LightCurve(None, prot_prior="invalid")


### PR DESCRIPTION
Before, if `prot_prior` was invalid, the code would fail, because it defined `process_resutl` (a typo) which would then have `process_result` be undefined on the return line.
Also, the concept of returning something empty when the input is invalid seems dangerous. That just means it's going to fail further down the line when some other function tried to read from the dict and nothing is in there. At that point, it's hard to debug. So, I moved the check up to fail with an actual error.

Then, I added a test to test that the error is raised. (Sure, it would be better to also test that an actual calculation gives the right answer, but one step at a time.)

When I tried to run that test, I discovered that I could not, because `acf_functions` imports pandas and statsmodels, which is not part of the requirements for Tessilator. pandas is never used, so I removed it (see also my other PR on removing unused imports) and I added `statsmodels` to the required dependencies.

As a side note: That shows that testing is very incomplete. Apparently no other test ever calls anything from this module, so it was never important and nobody ever noticed that it required other packages that are not listed as dependencies.