### PR TITLE
Add test run on Python 3.12

### DIFF
--- a/.github/workflows/tlr_tests.yml
+++ b/.github/workflows/tlr_tests.yml
@@ -52,10 +52,15 @@ jobs:
           #   python: 3.7
           #   toxenv: py37-test-oldestdeps
 
-          # - name: Python 3.8 with latest dev versions of key dependencies
-          #   os: ubuntu-latest
-          #   python: 3.8
-          #   toxenv: py38-test-devdeps
+          - name: Newest Python with latest dev versions of key dependencies
+            os: ubuntu-latest
+            python: 3.12
+            toxenv: py312-test-devdeps
+
+          # - name: Test building of Sphinx docs
+          #  os: ubuntu-latest
+          #  python: 3.x
+          #  toxenv: linkcheck
 
           # - name: Test building of Sphinx docs
           #   os: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310}-test{,-alldeps,-devdeps}{,-cov}
+    py{39,310,311,312}-test{,-alldeps,-devdeps}{,-cov}
     py{39,310}-test-numpy{117,118}
     py{39,310}-test-astropy{51,lts}
     build_docs
@@ -57,7 +57,7 @@ deps =
     astropy40: astropy==4.0.*
     astropylts: astropy==4.0.*
 
-    devdeps: :NIGHTLY:numpy
+    devdeps: numpy>=0.0.dev0
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
 
 # The following indicates which extras_require from setup.cfg will be installed


### PR DESCRIPTION
Running the CI only on 3.10 seems old. Let's add a newer version with newer numpy etc. to the mix.