### PR TITLE
Use context managers instead of setting the global rc_param state

### DIFF
--- a/tessilator/aperture.py
+++ b/tessilator/aperture.py
@@ -4,10 +4,10 @@ Alexander Binks & Moritz Guenther, 2024
 
 Licence: MIT 2024
 
-This module contains functions to perform aperture photmetry.
+This module contains functions to perform aperture photometry.
 
 The aperture photometry is defined by a single function 'aper_run', which reads
-the TESS image files, performs aperture phtoometry and returns an astropy table
+the TESS image files, performs aperture photometry and returns an astropy table
 containing the timestamps, magnitudes and fluxes derived from aperture
 photometry. Additionally, one can use the function 'calc_rad', which evaluates
 the relative brightness of neighbouring pixels to automatically determine the

--- a/tessilator/makeplots.py
+++ b/tessilator/makeplots.py
@@ -34,7 +34,7 @@ from .file_io import logger_tessilator
 
 
 # initialize the logger object
-logger = logger_tessilator(__name__) 
+logger = logger_tessilator(__name__)
 
 def create_plot(im_plot, clean, LS, scc, t_table, name_target, plot_dir,
                 xy_ctr=(10,10), xy_contam=None, p_min_thresh=0.1,
@@ -75,7 +75,7 @@ def create_plot(im_plot, clean, LS, scc, t_table, name_target, plot_dir,
     ap_rad : `float`, optional, default=1.0
         The aperture radius from the aperture photometry
     sky_ann : `Iterable`, size=2, optional, default=[6.,8.]
-        The inner and outer background annuli from aperture photometry  
+        The inner and outer background annuli from aperture photometry
     nc : `str`, optional, default='nc'
         Describes the type of noise correction applied to the lightcurve.
 
@@ -95,182 +95,272 @@ def create_plot(im_plot, clean, LS, scc, t_table, name_target, plot_dir,
     clean_orig_time = clean["time"]-t_0
     clean_orig_flux = clean["nflux_ori"]
     clean_orig_mag = clean["mag"]
-    
+
     clean_norm_time = clean["time"][c_1]-t_0
     clean_norm_flux = clean["nflux_ori"][c_1]
 
     clean_detr_time = clean["time"][cln_cond]-t_0
     clean_detr_flux = clean["nflux_dtr"][cln_cond]
-    mpl.rcParams.update({'font.size': 14})
+
     if LS["AIC_line"]+1. < LS["AIC_sine"]:
         best_fit_type = 'linear'
     else:
         best_fit_type = 'sine'
     fsize = 22.
     lsize = 0.9*fsize
-    fig, axs = plt.subplots(2,2, figsize=(20,15))
+    with plt.rc_context({"font.size": 14}):
+        fig, axs = plt.subplots(2, 2, figsize=(20, 15))
 
-    axs[0,0].set_position([0.05,0.55,0.40,0.40])
-    axs[0,1].set_position([0.55,0.55,0.40,0.40])
-    axs[1,0].set_position([0.05,0.3,0.90,0.2])
-    axs[1,1].set_position([0.05,0.05,0.90,0.2])
+        axs[0, 0].set_position([0.05, 0.55, 0.40, 0.40])
+        axs[0, 1].set_position([0.55, 0.55, 0.40, 0.40])
+        axs[1, 0].set_position([0.05, 0.3, 0.90, 0.2])
+        axs[1, 1].set_position([0.05, 0.05, 0.90, 0.2])
 
-    circ_aper = Circle(xy_ctr, ap_rad, linewidth=1.2, fill=False, color='r')
-    circ_ann1 = Circle(xy_ctr, sky_ann[0], linewidth=1.2, fill=False, color='b')
-    circ_ann2 = Circle(xy_ctr, sky_ann[1], linewidth=1.2, fill=False, color='b')
+        circ_aper = Circle(xy_ctr, ap_rad, linewidth=1.2, fill=False, color="r")
+        circ_ann1 = Circle(xy_ctr, sky_ann[0], linewidth=1.2, fill=False, color="b")
+        circ_ann2 = Circle(xy_ctr, sky_ann[1], linewidth=1.2, fill=False, color="b")
 
-    print(t_table)
-    with np.errstate(all='ignore'):
-        log_im_plot = np.log10(im_plot.data)
-        image_plot = np.ma.array(log_im_plot, mask=np.isnan(log_im_plot))
-    im_fig = axs[0,0].imshow(image_plot, cmap='binary')
-    Gaia_name = f"{t_table['source_id'][0]}"
-    targ_name = t_table['name'][0]
-    fig.text(0.5,0.96,
-             f"{targ_name}, Sector {scc[0]}, "
-             f"Camera {scc[1]}, "
-             f"CCD {scc[2]}",
-             fontsize=lsize*2.0,
-             horizontalalignment='center')
-    axs[0,0].set_xlabel("x pixel", fontsize=fsize)
-    axs[0,0].set_ylabel("y pixel", fontsize=fsize)
-    axs[0,0].add_patch(circ_aper)
-    axs[0,0].add_patch(circ_ann1)
-    axs[0,0].add_patch(circ_ann2)
-    axs[0,0].text(0.01,0.94, "$r_{\\rm ap}$ = "
-                  f"{ap_rad:.2f}", color='red',
-                  fontsize=lsize,horizontalalignment='left', 
-                  transform=axs[0,0].transAxes)
-    if isinstance(xy_contam, Iterable):
-        axs[0,0].scatter(xy_contam[:, 0], xy_contam[:, 1], marker='X',
-                         s=400, color='orange')
-    divider = make_axes_locatable(axs[0,0])
-    cax = divider.new_horizontal(size='5%', pad=0.4)
-    fig.add_axes(cax)
-    cbar = fig.colorbar(im_fig, cax=cax)
-    cbar.set_label('log$_{10}$ counts (e$^-$/s)', rotation=270, labelpad=+15)
-
-    axs[0,1].set_xlim([p_min_thresh, p_max_thresh])
-    axs[0,1].grid(True)
-    axs[0,1].set_xlabel("Period (days)", fontsize=fsize)
-    axs[0,1].set_ylabel("Power", fontsize=fsize)
-    axs[0,1].semilogx(LS['period_a_1'], LS['power_a_1'])
-    [axs[0,1].axhline(y=i, linestyle='--', color='grey', alpha=0.8) \
-     for i in LS['FAPs']]
-    axs[0,1].text(0.01,0.94, f"Best fit: {best_fit_type}",
-                  fontsize=lsize,horizontalalignment='left', 
-                  transform=axs[0,1].transAxes)
-    axs[0,1].text(0.99,0.94, "$P_{\\rm rot}^{\\rm (max)}$ = "
-                  f"{LS['period_1']:.3f} days, "
-                  f"power = {LS['power_1']:.3f}",
-                  fontsize=lsize, horizontalalignment='right',
-                  transform=axs[0,1].transAxes)
-    axs[0,1].text(0.99,0.82, "$P_{\\rm rot}^{\\rm (2nd)}$ = "
-                  f"{LS['period_2']:.3f}",
-                  fontsize=lsize, horizontalalignment='right',
-                  transform=axs[0,1].transAxes)
-    axs[0,1].text(0.99,0.76, f"power ratio = "
-                  f"{LS['power_1']/LS['power_2']:.3f}",
-                  fontsize=lsize,horizontalalignment='right', 
-                  transform=axs[0,1].transAxes)
-
-    if (LS['Gauss_1'][1] != 15) & \
-       (isinstance(LS['period_around_1'], Iterable)):
-        axs[0,1].plot(LS['period_around_1'],
-                      LS['Gauss_y_1'],
-                      c='r', label='Best fit')
-        axs[0,1].text(0.99,0.88, "$P_{\\rm rot}^{\\rm (Gauss)}$ = "
-                      f"{LS['Gauss_1'][1]:.3f} $\\pm$"
-                      f"{LS['Gauss_1'][2]:.3f}",
-                      fontsize=lsize, horizontalalignment='right',
-                      transform=axs[0,1].transAxes)    
-    if LS['shuffle_flag'] > 0:
-        axs[0,1].axvline(x=LS['period_1'], color='red', linewidth=3, alpha=0.3)
-    axs[1,0].set_xlim([0, 30])
-    axs[1,0].set_xlabel("Time (days)", fontsize=fsize)
-    axs[1,0].set_ylim(
-        [LS['median_MAD_nLC'][0]-(8.*LS['median_MAD_nLC'][1]),
-        LS['median_MAD_nLC'][0]+(8.*LS['median_MAD_nLC'][1])])
-    axs[1,0].set_ylabel("normalised flux", c='g', fontsize=fsize)
-    axs[1,0].plot(LS["time"]-t_0, LS['y_fit_LS'], c='orange',
-                  linewidth=1.5, label='LS best fit')
-    axs[1,0].scatter(clean_orig_time, clean_orig_flux, s=1.0, c='pink',
-                     alpha=0.5, label='raw, normalized')
-    axs[1,0].scatter(clean_norm_time, clean_norm_flux, s=1.0, c='r', 
-                     alpha=0.5, label='cleaned, normalized')
-    axs[1,0].scatter(clean_detr_time, clean_detr_flux, s=1.2, c='g',
-                     alpha=0.7, label='cleaned, normalized, detrended')
-    if LS['jump_flag']:
-        axs[1,0].text(0.01,0.90, 'Jumps detected', fontsize=lsize,
-                      horizontalalignment='left',
-                      transform=axs[1,0].transAxes)
-    if LS["CBV_flag"] == 1:
-        axs[1, 0].text(
+        print(t_table)
+        with np.errstate(all="ignore"):
+            log_im_plot = np.log10(im_plot.data)
+            image_plot = np.ma.array(log_im_plot, mask=np.isnan(log_im_plot))
+        im_fig = axs[0, 0].imshow(image_plot, cmap="binary")
+        Gaia_name = f"{t_table['source_id'][0]}"
+        targ_name = t_table["name"][0]
+        fig.text(
+            0.5,
+            0.96,
+            f"{targ_name}, Sector {scc[0]}, Camera {scc[1]}, CCD {scc[2]}",
+            fontsize=lsize * 2.0,
+            horizontalalignment="center",
+        )
+        axs[0, 0].set_xlabel("x pixel", fontsize=fsize)
+        axs[0, 0].set_ylabel("y pixel", fontsize=fsize)
+        axs[0, 0].add_patch(circ_aper)
+        axs[0, 0].add_patch(circ_ann1)
+        axs[0, 0].add_patch(circ_ann2)
+        axs[0, 0].text(
             0.01,
-            0.01,
-            "best fit: original flux",
+            0.94,
+            f"$r_{{\\rm ap}}$ = {ap_rad:.2f}",
+            color="red",
             fontsize=lsize,
             horizontalalignment="left",
-            transform=axs[1, 0].transAxes,
+            transform=axs[0, 0].transAxes,
         )
-    if LS["CBV_flag"] == 2:
-        axs[1, 0].text(
+        if isinstance(xy_contam, Iterable):
+            axs[0, 0].scatter(
+                xy_contam[:, 0], xy_contam[:, 1], marker="X", s=400, color="orange"
+            )
+        divider = make_axes_locatable(axs[0, 0])
+        cax = divider.new_horizontal(size="5%", pad=0.4)
+        fig.add_axes(cax)
+        cbar = fig.colorbar(im_fig, cax=cax)
+        cbar.set_label("log$_{10}$ counts (e$^-$/s)", rotation=270, labelpad=+15)
+
+        axs[0, 1].set_xlim([p_min_thresh, p_max_thresh])
+        axs[0, 1].grid(True)
+        axs[0, 1].set_xlabel("Period (days)", fontsize=fsize)
+        axs[0, 1].set_ylabel("Power", fontsize=fsize)
+        axs[0, 1].semilogx(LS["period_a_1"], LS["power_a_1"])
+        [
+            axs[0, 1].axhline(y=i, linestyle="--", color="grey", alpha=0.8)
+            for i in LS["FAPs"]
+        ]
+        axs[0, 1].text(
             0.01,
-            0.01,
-            "best fit: CBV corrected flux",
+            0.94,
+            f"Best fit: {best_fit_type}",
             fontsize=lsize,
             horizontalalignment="left",
+            transform=axs[0, 1].transAxes,
+        )
+        axs[0, 1].text(
+            0.99,
+            0.94,
+            "$P_{\\rm rot}^{\\rm (max)}$ = "
+            f"{LS['period_1']:.3f} days, "
+            f"power = {LS['power_1']:.3f}",
+            fontsize=lsize,
+            horizontalalignment="right",
+            transform=axs[0, 1].transAxes,
+        )
+        axs[0, 1].text(
+            0.99,
+            0.82,
+            f"$P_{{\\rm rot}}^{{\\rm (2nd)}}$ = {LS['period_2']:.3f}",
+            fontsize=lsize,
+            horizontalalignment="right",
+            transform=axs[0, 1].transAxes,
+        )
+        axs[0, 1].text(
+            0.99,
+            0.76,
+            f"power ratio = {LS['power_1'] / LS['power_2']:.3f}",
+            fontsize=lsize,
+            horizontalalignment="right",
+            transform=axs[0, 1].transAxes,
+        )
+
+        if (LS["Gauss_1"][1] != 15) & (isinstance(LS["period_around_1"], Iterable)):
+            axs[0, 1].plot(
+                LS["period_around_1"], LS["Gauss_y_1"], c="r", label="Best fit"
+            )
+            axs[0, 1].text(
+                0.99,
+                0.88,
+                "$P_{\\rm rot}^{\\rm (Gauss)}$ = "
+                f"{LS['Gauss_1'][1]:.3f} $\\pm$"
+                f"{LS['Gauss_1'][2]:.3f}",
+                fontsize=lsize,
+                horizontalalignment="right",
+                transform=axs[0, 1].transAxes,
+            )
+        if LS["shuffle_flag"] > 0:
+            axs[0, 1].axvline(x=LS["period_1"], color="red", linewidth=3, alpha=0.3)
+        axs[1, 0].set_xlim([0, 30])
+        axs[1, 0].set_xlabel("Time (days)", fontsize=fsize)
+        axs[1, 0].set_ylim(
+            [
+                LS["median_MAD_nLC"][0] - (8.0 * LS["median_MAD_nLC"][1]),
+                LS["median_MAD_nLC"][0] + (8.0 * LS["median_MAD_nLC"][1]),
+            ]
+        )
+        axs[1, 0].set_ylabel("normalised flux", c="g", fontsize=fsize)
+        axs[1, 0].plot(
+            LS["time"] - t_0,
+            LS["y_fit_LS"],
+            c="orange",
+            linewidth=1.5,
+            label="LS best fit",
+        )
+        axs[1, 0].scatter(
+            clean_orig_time,
+            clean_orig_flux,
+            s=1.0,
+            c="pink",
+            alpha=0.5,
+            label="raw, normalized",
+        )
+        axs[1, 0].scatter(
+            clean_norm_time,
+            clean_norm_flux,
+            s=1.0,
+            c="r",
+            alpha=0.5,
+            label="cleaned, normalized",
+        )
+        axs[1, 0].scatter(
+            clean_detr_time,
+            clean_detr_flux,
+            s=1.2,
+            c="g",
+            alpha=0.7,
+            label="cleaned, normalized, detrended",
+        )
+        if LS["jump_flag"]:
+            axs[1, 0].text(
+                0.01,
+                0.90,
+                "Jumps detected",
+                fontsize=lsize,
+                horizontalalignment="left",
+                transform=axs[1, 0].transAxes,
+            )
+        if LS["CBV_flag"] == 1:
+            axs[1, 0].text(
+                0.01,
+                0.01,
+                "best fit: original flux",
+                fontsize=lsize,
+                horizontalalignment="left",
+                transform=axs[1, 0].transAxes,
+            )
+        if LS["CBV_flag"] == 2:
+            axs[1, 0].text(
+                0.01,
+                0.01,
+                "best fit: CBV corrected flux",
+                fontsize=lsize,
+                horizontalalignment="left",
+                transform=axs[1, 0].transAxes,
+            )
+        axs[1, 0].text(
+            0.99,
+            0.90,
+            Gaia_name,
+            fontsize=lsize,
+            horizontalalignment="right",
             transform=axs[1, 0].transAxes,
         )
-    axs[1,0].text(0.99,0.90, Gaia_name, fontsize=lsize,
-                  horizontalalignment='right',
-                  transform=axs[1,0].transAxes)
-    axs[1,0].text(0.99,0.80, f"Gmag = {float(t_table['Gmag']):.3f}",
-                  fontsize=lsize, horizontalalignment='right',
-                  transform=axs[1,0].transAxes)
-    axs[1,0].text(0.99,0.70, "$\log (f_{\\rm bg}/f_{*})$ = "
-                  f"{float(t_table['log_tot_bg']):.3f}", fontsize=lsize,
-                  horizontalalignment='right', transform=axs[1,0].transAxes)
-    leg = axs[1,0].legend(loc='lower right')
-    leg.legendHandles[1]._sizes = [30]
-    leg.legendHandles[2]._sizes = [30]
-    leg.legendHandles[3]._sizes = [30]
-    ax2=axs[1,0].twinx()
-    ax2.set_position([0.05,0.3,0.90,0.2])
-    ax2.invert_yaxis()
+        axs[1, 0].text(
+            0.99,
+            0.80,
+            f"Gmag = {float(t_table['Gmag']):.3f}",
+            fontsize=lsize,
+            horizontalalignment="right",
+            transform=axs[1, 0].transAxes,
+        )
+        axs[1, 0].text(
+            0.99,
+            0.70,
+            f"$\log (f_{{\\rm bg}}/f_{{*}})$ = {float(t_table['log_tot_bg']):.3f}",
+            fontsize=lsize,
+            horizontalalignment="right",
+            transform=axs[1, 0].transAxes,
+        )
+        leg = axs[1, 0].legend(loc="lower right")
+        leg.legendHandles[1]._sizes = [30]
+        leg.legendHandles[2]._sizes = [30]
+        leg.legendHandles[3]._sizes = [30]
+        ax2 = axs[1, 0].twinx()
+        ax2.set_position([0.05, 0.3, 0.90, 0.2])
+        ax2.invert_yaxis()
 
-    if not np.all(clean_orig_mag.data == -999.):
-        ax2.scatter(clean_orig_time[clean_orig_mag>-999],
-                    clean_orig_mag[clean_orig_mag>-999],
-                    s=0.3, alpha=0.3, color="b", marker="x")
-        ax2.set_ylabel("TESS magnitude", c="b",fontsize=fsize)
+        if not np.all(clean_orig_mag.data == -999.0):
+            ax2.scatter(
+                clean_orig_time[clean_orig_mag > -999],
+                clean_orig_mag[clean_orig_mag > -999],
+                s=0.3,
+                alpha=0.3,
+                color="b",
+                marker="x",
+            )
+            ax2.set_ylabel("TESS magnitude", c="b", fontsize=fsize)
 
-    axs[1,1].set_xlim([0,1])
-    axs[1,1].set_xlabel("phase", fontsize=fsize)
-    axs[1,1].set_ylabel("normalised flux", fontsize=fsize)
-    axs[1,1].plot(LS['phase_fit_x'], LS['phase_fit_y'], c='b')
-    LS["phase_col"] += 1
-    N_cyc = int(max(LS["phase_col"]))
-    cmap_use = plt.get_cmap('rainbow', N_cyc)
-    s = axs[1,1].scatter(LS['phase_x'], LS["phase_y"],
-                         c=LS['phase_col'], cmap=cmap_use, vmin=0.5,
-                         vmax=N_cyc+0.5)
-#    axs[1,1].text(0.01, 0.90, f"Amplitude = {LS['amp']:.3f}, "
-#                  f"Scatter = {LS['scatter']:.3f}, "
-#                  f"$\chi^{2}$ = {LS['chisq_phase']:.3f}, "
-#                  "$f_{\\rm dev}$"+ f"= {LS['fdev']:.3f}",
-#                  fontsize=lsize, horizontalalignment='left',
-#                  transform=axs[1,1].transAxes)
+        axs[1, 1].set_xlim([0, 1])
+        axs[1, 1].set_xlabel("phase", fontsize=fsize)
+        axs[1, 1].set_ylabel("normalised flux", fontsize=fsize)
+        axs[1, 1].plot(LS["phase_fit_x"], LS["phase_fit_y"], c="b")
+        LS["phase_col"] += 1
+        N_cyc = int(max(LS["phase_col"]))
+        cmap_use = plt.get_cmap("rainbow", N_cyc)
+        s = axs[1, 1].scatter(
+            LS["phase_x"],
+            LS["phase_y"],
+            c=LS["phase_col"],
+            cmap=cmap_use,
+            vmin=0.5,
+            vmax=N_cyc + 0.5,
+        )
+        #    axs[1,1].text(0.01, 0.90, f"Amplitude = {LS['amp']:.3f}, "
+        #                  f"Scatter = {LS['scatter']:.3f}, "
+        #                  f"$\chi^{2}$ = {LS['chisq_phase']:.3f}, "
+        #                  "$f_{\\rm dev}$"+ f"= {LS['fdev']:.3f}",
+        #                  fontsize=lsize, horizontalalignment='left',
+        #                  transform=axs[1,1].transAxes)
 
-#    cbaxes = inset_axes(axs[1,1], width="100%", height="100%",
-#                        bbox_to_anchor=(0.79, 0.92, 0.20, 0.05),
-#                        bbox_transform=axs[1,1].transAxes)
-#    cbar = plt.colorbar(s, cax=cbaxes, orientation='horizontal',
-#                        label='cycle number')
-    plot_name = '_'.join([name_target, f"{scc[0]:04d}",
-                          f"{scc[1]}", f"{scc[2]}", f"{nc}"])+'.png'
-    plt.savefig(f'./{plot_dir}/{plot_name}', bbox_inches='tight')
-    plt.close('all')
+        #    cbaxes = inset_axes(axs[1,1], width="100%", height="100%",
+        #                        bbox_to_anchor=(0.79, 0.92, 0.20, 0.05),
+        #                        bbox_transform=axs[1,1].transAxes)
+        #    cbar = plt.colorbar(s, cax=cbaxes, orientation='horizontal',
+        #                        label='cycle number')
+        plot_name = (
+            "_".join([name_target, f"{scc[0]:04d}", f"{scc[1]}", f"{scc[2]}", f"{nc}"])
+            + ".png"
+        )
+        plt.savefig(f"./{plot_dir}/{plot_name}", bbox_inches="tight")
+        plt.close("all")
 
 
 __all__ = [item[0] for item in inspect.getmembers(sys.modules[__name__],

--- a/tessilator/maketable.py
+++ b/tessilator/maketable.py
@@ -98,8 +98,7 @@ def table_from_simbad(input_names):
             else:
                 logger.error(f"Could not find any match for '{input_name}'")
         else: # Simbad returns at least one identifier
-            r_list = [z for z in res["id"]]
-            m = [s for s in r_list if "Gaia DR3" in s]
+            m = [s for s in res["id"] if "Gaia DR3" in s]
             if len(m) == 0: # if Gaia identifier is not in the Simbad list
                 if is_Gaia[i] == 1:
                     logger.warning("Simbad didn't resolve Gaia DR3 "

--- a/tessilator/tessilator.py
+++ b/tessilator/tessilator.py
@@ -346,7 +346,7 @@ def read_data(t_filename, name_is_source_id=False, type_coord='icrs',
     
     (b) a 2-column table of decimal sky coordinates (celestial or galactic).
     
-    (c) a pre-prepared table of 7 columns consisting of source_id, ra, dec,
+    (c) a table of 7 columns consisting of source_id, ra, dec,
         parallax, Gmag, BPmag, RPmag (without column headers).
     
     Note that a single target can be quickly analysed directly from the
@@ -354,7 +354,7 @@ def read_data(t_filename, name_is_source_id=False, type_coord='icrs',
     and then encompassed with double-quotation marks around the source
     identifier.
     
-    E.G. >>> python run_tess_cutouts files "#AB Doradus"
+        >>> python run_tess_cutouts files "#AB Doradus"
     
     parameters
     ----------
@@ -729,20 +729,19 @@ def make_lc_corr_plot(plot_name, ref_name, targ_time, targ_flux, sim_flux,
     -------
     None. Plots are saved to file.
     '''    
-    fig, ax = plt.subplots(figsize=(15,7))
-    mpl.rcParams.update({'font.size': 20})
-    ax.set_xlabel('time [days]')
-    ax.set_ylabel('normalised flux')
-    ax.plot(targ_time, targ_flux, '.', c='r', label='target flux')
-    ax.plot(targ_time, sim_flux, '.', c='g', label='systematic flux')
-    ax.legend()
-    im_dir_tot = f'./{im_dir}/{ref_name}'
-    path_exist = os.path.exists(im_dir_tot)
-    if not path_exist:
-        os.mkdir(im_dir_tot)
-    plt.savefig(f'{im_dir_tot}/{plot_name}', bbox_inches='tight')
-    plt.close('all')
-
+    with plt.rc_context({'font.size': 20}):
+        fig, ax = plt.subplots(figsize=(15,7))
+        ax.set_xlabel('time [days]')
+        ax.set_ylabel('normalised flux')
+        ax.plot(targ_time, targ_flux, '.', c='r', label='target flux')
+        ax.plot(targ_time, sim_flux, '.', c='g', label='systematic flux')
+        ax.legend()
+        im_dir_tot = f'./{im_dir}/{ref_name}'
+        path_exist = os.path.exists(im_dir_tot)
+        if not path_exist:
+            os.mkdir(im_dir_tot)
+        fig.savefig(f'{im_dir_tot}/{plot_name}', bbox_inches='tight')
+        plt.close('all')
 
 
 def get_name_target(t_target):


### PR DESCRIPTION
There were two locations in the tessilator, where the tessilator changes the global state of the matplotlib defaults (the font size).
When using the tessilator in the Python program (as opposed to a command line tool that exists after the plots are done), then any other plot made after calling the tessilator will also have those settings, if I like it or not.
So, instead, this commit replaces the change of the global state with a context that changes the fontsize only for that one plot.

Also included in the commit are a few unrelated typos that I found while looking through the files, and a simplifications of a loop, that I stumbled upon. None of them change the behavior, and I just figured I might as well fix them if I happen to catch them serendipously.