### PR TITLE
Fix legend formatting for newer versions of matplotlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ tessilator.egg-info/PKG-INFO
 tessilator.egg-info/SOURCES.txt
 
 
-
+*.log
 
 # TAKEN FROM ASTROPY
 # Compiled files

--- a/tessilator/makeplots.py
+++ b/tessilator/makeplots.py
@@ -228,13 +228,15 @@ def create_plot(im_plot, clean, LS, scc, t_table, name_target, plot_dir,
     axs[1,0].text(0.99,0.80, f"Gmag = {float(t_table['Gmag']):.3f}",
                   fontsize=lsize, horizontalalignment='right',
                   transform=axs[1,0].transAxes)
-    axs[1,0].text(0.99,0.70, "$\log (f_{\\rm bg}/f_{*})$ = "
-                  f"{float(t_table['log_tot_bg']):.3f}", fontsize=lsize,
-                  horizontalalignment='right', transform=axs[1,0].transAxes)
-    leg = axs[1,0].legend(loc='lower right')
-    leg.legendHandles[1]._sizes = [30]
-    leg.legendHandles[2]._sizes = [30]
-    leg.legendHandles[3]._sizes = [30]
+    axs[1, 0].text(
+        0.99,
+        0.70,
+        f"$\\log (f_{{\\rm bg}}/f_{{*}})$ = {float(t_table['log_tot_bg']):.3f}",
+        fontsize=lsize,
+        horizontalalignment="right",
+        transform=axs[1, 0].transAxes,
+    )
+    axs[1, 0].legend(loc="lower right", markerscale=10)
     ax2=axs[1,0].twinx()
     ax2.set_position([0.05,0.3,0.90,0.2])
     ax2.invert_yaxis()
@@ -269,7 +271,7 @@ def create_plot(im_plot, clean, LS, scc, t_table, name_target, plot_dir,
 #                        label='cycle number')
     plot_name = '_'.join([name_target, f"{scc[0]:04d}",
                           f"{scc[1]}", f"{scc[2]}", f"{nc}"])+'.png'
-    plt.savefig(f'./{plot_dir}/{plot_name}', bbox_inches='tight')
+    fig.savefig(f"./{plot_dir}/{plot_name}", bbox_inches="tight")
     plt.close('all')
 
 

--- a/tessilator/tests/test_tessilator.py
+++ b/tessilator/tests/test_tessilator.py
@@ -43,11 +43,9 @@ def test_all_sources_cutout(tmpdir):
         tessilator.all_sources_cutout(
             ABDor,
             period_file="period",
-            lc_con=False,
-            flux_con=False,
-            make_plots=True,
             ref_name="ABDor",
             choose_sec=33,
+            make_plot=True,
         )
     assert os.path.isfile(f"{tmpdir}/fits/ABDor/AB_Dor_0033_4_2.fits")
     # Checking how a matplotlib file looks is more complicated,
@@ -66,7 +64,6 @@ def test_all_sources_cutout(tmpdir):
     assert out["original_id"][0] == ABDor["name"]
     # Just test a few representative columns
     assert out["Sector"][0] == 33
-    assert out["num_tot_bg"].mask[0]
     assert (
         out["ap_rad"][0] == 1.926
     )  # The csv writer sets the precision, so this is exact
@@ -86,7 +83,6 @@ def test_all_sources_cutout_no_data(tmpdir):
         tessilator.all_sources_sector(
             tTargets,
             scc=[16, 4, 3],
-            make_plots=False,
             period_file="period",
             file_ref="ABDor",
             keep_data=False,


### PR DESCRIPTION
For the current matplotlib (I believe from 3.9.0 on) legend no longer has a `legendHandles` attribute, it is now named differently. This leads to a an exception in matplotlib, which will cause `createplot` to not create a plot, and instead raise an exception. Unfortunately, the user never sees that exception: The exception bubbles up through `full_run_lc` which in turn is called by `one_source_cutout` and in `one_source_cutout` there is a blanket statement that catches all exceptions and simply writes a single line tothe logfile ("Error occurred when processing {file_in}. Trying next target.").
Thus, we never know that there is a problem and that that problem comes from a change in matplotlib.

I found it when running the tessilator tests with remote data, which fails because the plot is not created. It still took me a long time to dig down to WHY the plot is not created.

This commit fixes the matplotlib problem using a different way to set the size of the scatter dots in the legend that is hopefully more portable between version as it does not rely on an attribute of method that is marked private.

The PR includes a change to test that, for some reasons didn't work because the name of the aguments had been changed inthe code, but not in the tests. So, apparently the tests were not run before for some reason.