### PR TITLE
Replace the use of pgk_resources

### DIFF
--- a/tessilator/__init__.py
+++ b/tessilator/__init__.py
@@ -1,5 +1,7 @@
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import version, PackageNotFoundError
+
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    pass  # package is not installed
+    __version__ = version("tessilator")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/tessilator/tests/test_version.py
+++ b/tessilator/tests/test_version.py
@@ -1,0 +1,5 @@
+def test_version():
+    from tessilator import __version__
+    assert __version__ is not None, "Version should not be None"
+    assert isinstance(__version__, str), "Version should be a string"
+    assert len(__version__) > 0, "Version string should not be empty"


### PR DESCRIPTION
[`pkg_resources`' is deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html) and will stop working with setuptools as soon as November this year. In fact, it has already broken our testing wiht dev dependencies: https://setuptools.pypa.io/en/latest/pkg_resources.html